### PR TITLE
FIX PIPELINE

### DIFF
--- a/src/main/java/arsw/wherewe/back/papagroups/controller/GroupController.java
+++ b/src/main/java/arsw/wherewe/back/papagroups/controller/GroupController.java
@@ -1,5 +1,6 @@
 package arsw.wherewe.back.papagroups.controller;
 
+import arsw.wherewe.back.papagroups.dto.GroupDTO;
 import arsw.wherewe.back.papagroups.model.Group;
 import arsw.wherewe.back.papagroups.service.GroupService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -37,9 +38,9 @@ public class GroupController {
             @ApiResponse(responseCode = "400", description = "Invalid group data provided")
     })
     @PostMapping
-    public ResponseEntity<Group> createGroup(@RequestBody Group group) {
-        Group newGroup = groupService.createGroup(group);
-        if(newGroup == null){
+    public ResponseEntity<GroupDTO> createGroup(@RequestBody GroupDTO groupDTO) {
+        GroupDTO newGroup = groupService.createGroup(groupDTO);
+        if (newGroup == null) {
             return ResponseEntity.badRequest().build();
         }
         return ResponseEntity.ok(newGroup);
@@ -52,9 +53,9 @@ public class GroupController {
                     content = @Content(schema = @Schema(implementation = Group.class))),
             @ApiResponse(responseCode = "204", description = "No groups found")
     })
-    public ResponseEntity<List<Group>> getGroups() {
-        List<Group> groups = groupService.getGroups();
-        if(!groups.isEmpty()) {
+    public ResponseEntity<List<GroupDTO>> getGroups() {
+        List<GroupDTO> groups = groupService.getGroups();
+        if (!groups.isEmpty()) {
             return ResponseEntity.ok(groups);
         } else {
             return ResponseEntity.noContent().build();
@@ -68,9 +69,9 @@ public class GroupController {
                     content = @Content(schema = @Schema(implementation = Group.class))),
             @ApiResponse(responseCode = "404", description = "Group not found")
     })
-    public ResponseEntity<Group> getGroupById(@PathVariable("id") String id) {
-        Group group = groupService.getGroupById(id);
-        if(group != null) {
+    public ResponseEntity<GroupDTO> getGroupById(@PathVariable("id") String id) {
+        GroupDTO group = groupService.getGroupById(id);
+        if (group != null) {
             return ResponseEntity.ok(group);
         } else {
             return ResponseEntity.noContent().build();
@@ -84,12 +85,17 @@ public class GroupController {
                     content = @Content(schema = @Schema(implementation = Group.class))),
             @ApiResponse(responseCode = "400", description = "User already in group or group not found")
     })
-    public ResponseEntity<Group> joinGroup(@PathVariable("code") String code, @PathVariable("userId") String userId){
-        Group group = groupService.joinGroup(code, userId);
-        if(group != null) {
-            return ResponseEntity.ok(group);
-        } else {
-            return ResponseEntity.badRequest().build();
+    public ResponseEntity<GroupDTO> joinGroup(@PathVariable("code") String code, @PathVariable("userId") String userId) {
+        try {
+            GroupDTO group = groupService.joinGroup(code, userId);
+            if (group != null) {
+                return ResponseEntity.ok(group);
+            } else {
+                return ResponseEntity.badRequest().build();
+            }
+        } catch (IllegalArgumentException e) {
+            // include an error message
+            return ResponseEntity.badRequest().body(null);
         }
     }
 
@@ -100,9 +106,9 @@ public class GroupController {
                     content = @Content(schema = @Schema(implementation = Group.class))),
             @ApiResponse(responseCode = "204", description = "No groups found for the user")
     })
-    public ResponseEntity<List<Group>> getGroupsByUserId(@PathVariable("userId") String userId){
-        List<Group> groups = groupService.getGroupsByUserId(userId);
-        if(!groups.isEmpty()) {
+    public ResponseEntity<List<GroupDTO>> getGroupsByUserId(@PathVariable("userId") String userId) {
+        List<GroupDTO> groups = groupService.getGroupsByUserId(userId);
+        if (!groups.isEmpty()) {
             return ResponseEntity.ok(groups);
         } else {
             return ResponseEntity.noContent().build();

--- a/src/main/java/arsw/wherewe/back/papagroups/dto/GroupDTO.java
+++ b/src/main/java/arsw/wherewe/back/papagroups/dto/GroupDTO.java
@@ -1,0 +1,77 @@
+package arsw.wherewe.back.papagroups.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "DTO representing a group in the system")
+public class GroupDTO {
+
+    @Schema(description = "Unique identifier of the group", example = "507f1f77bcf86cd799439011")
+    private String id;
+
+    @Schema(description = "ID of the group admin", example = "admin123")
+    private String admin;
+
+    @Schema(description = "Name of the group", example = "Study Group")
+    private String nameGroup;
+
+    @Schema(description = "List of member IDs in the group", example = "[\"user1\", \"user2\"]")
+    private List<String> members;
+
+    @Schema(description = "Unique code to join the group", example = "ABC123")
+    private String code;
+
+    // Constructors
+    public GroupDTO() {
+    }
+
+    public GroupDTO(String id, String admin, String nameGroup, List<String> members, String code) {
+        this.id = id;
+        this.admin = admin;
+        this.nameGroup = nameGroup;
+        this.members = members;
+        this.code = code;
+    }
+
+    // Getters and Setters
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getAdmin() {
+        return admin;
+    }
+
+    public void setAdmin(String admin) {
+        this.admin = admin;
+    }
+
+    public String getNameGroup() {
+        return nameGroup;
+    }
+
+    public void setNameGroup(String nameGroup) {
+        this.nameGroup = nameGroup;
+    }
+
+    public List<String> getMembers() {
+        return members;
+    }
+
+    public void setMembers(List<String> members) {
+        this.members = members;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+}

--- a/src/main/java/arsw/wherewe/back/papagroups/service/GroupService.java
+++ b/src/main/java/arsw/wherewe/back/papagroups/service/GroupService.java
@@ -1,5 +1,6 @@
 package arsw.wherewe.back.papagroups.service;
 
+import arsw.wherewe.back.papagroups.dto.GroupDTO;
 import arsw.wherewe.back.papagroups.model.Group;
 import arsw.wherewe.back.papagroups.repository.GroupRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * Group service class for group operations
@@ -23,34 +25,62 @@ public class GroupService {
         this.groupRepository = groupRepository;
     }
 
-    public Group createGroup(Group group) {
+    // Map Group to GroupDTO
+    private GroupDTO toGroupDTO(Group group) {
+        return new GroupDTO(
+                group.getId(),
+                group.getAdmin(),
+                group.getNameGroup(),
+                group.getMembers(),
+                group.getCode()
+        );
+    }
+
+    // Map GroupDTO to Group
+    private Group toGroup(GroupDTO groupDTO) {
+        return new Group(
+                groupDTO.getId(),
+                groupDTO.getAdmin(),
+                groupDTO.getNameGroup(),
+                groupDTO.getMembers(),
+                groupDTO.getCode()
+        );
+    }
+
+    public GroupDTO createGroup(GroupDTO groupDTO) {
+        Group group = toGroup(groupDTO);
         group.setCode(generateCode());
         group.setMembers(List.of(group.getAdmin()));
-        return groupRepository.save(group);
+        Group savedGroup = groupRepository.save(group);
+        return toGroupDTO(savedGroup);
     }
 
-    public List<Group> getGroups() {
-        return groupRepository.findAll();
+    public List<GroupDTO> getGroups() {
+        return groupRepository.findAll().stream()
+                .map(this::toGroupDTO)
+                .collect(Collectors.toList());
     }
 
-    public Group getGroupById(String id) {
-        return groupRepository.findById(id).orElse(null);
+    public GroupDTO getGroupById(String id) {
+        Group group = groupRepository.findById(id).orElse(null);
+        return group != null ? toGroupDTO(group) : null;
     }
 
-    public Group joinGroup(String code, String userId){
+    public GroupDTO joinGroup(String code, String userId) {
         Optional<Group> groupOptional = groupRepository.findAll().stream()
                 .filter(g -> g.getCode().equals(code))
                 .findFirst();
 
-        if(groupOptional.isPresent()){
+        if (groupOptional.isPresent()) {
             Group group = groupOptional.get();
-            if (!group.getMembers().contains(userId)){
+            if (!group.getMembers().contains(userId)) {
                 group.getMembers().add(userId);
-                return groupRepository.save(group);
-            }else {
+                Group updatedGroup = groupRepository.save(group);
+                return toGroupDTO(updatedGroup);
+            } else {
                 throw new IllegalArgumentException("El usuario ya pertenece al grupo");
             }
-        }else {
+        } else {
             throw new IllegalArgumentException("El grupo no existe");
         }
     }
@@ -64,10 +94,11 @@ public class GroupService {
      * Get all groups by userId
      * @param userId String user id
      */
-    public List<Group> getGroupsByUserId(String userId) {
+    public List<GroupDTO> getGroupsByUserId(String userId) {
         return groupRepository.findAll().stream()
                 .filter(g -> g.getMembers().contains(userId))
-                .toList();
+                .map(this::toGroupDTO)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/test/java/arsw/wherewe/back/papagroups/controller/GroupControllerTests.java
+++ b/src/test/java/arsw/wherewe/back/papagroups/controller/GroupControllerTests.java
@@ -1,6 +1,6 @@
 package arsw.wherewe.back.papagroups.controller;
 
-import arsw.wherewe.back.papagroups.model.Group;
+import arsw.wherewe.back.papagroups.dto.GroupDTO;
 import arsw.wherewe.back.papagroups.service.GroupService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,23 +36,23 @@ class GroupControllerTests {
 
     @Test
     void createGroupSuccessfully() throws Exception {
-        Group group = new Group();
-        group.setAdmin("adminId");
+        GroupDTO groupDTO = new GroupDTO();
+        groupDTO.setAdmin("adminId");
 
-        when(groupService.createGroup(any(Group.class))).thenReturn(group);
+        when(groupService.createGroup(any(GroupDTO.class))).thenReturn(groupDTO);
 
         mockMvc.perform(post("/api/v1/groups")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"admin\":\"adminId\"}"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"admin\":\"adminId\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.admin").value("adminId"));
 
-        verify(groupService, times(1)).createGroup(any(Group.class));
+        verify(groupService, times(1)).createGroup(any(GroupDTO.class));
     }
 
     @Test
     void getGroupsSuccessfully() throws Exception {
-        List<Group> groups = List.of(new Group(), new Group());
+        List<GroupDTO> groups = List.of(new GroupDTO(), new GroupDTO());
 
         when(groupService.getGroups()).thenReturn(groups);
 
@@ -65,10 +65,10 @@ class GroupControllerTests {
 
     @Test
     void getGroupByIdSuccessfully() throws Exception {
-        Group group = new Group();
-        group.setId("groupId");
+        GroupDTO groupDTO = new GroupDTO();
+        groupDTO.setId("groupId");
 
-        when(groupService.getGroupById("groupId")).thenReturn(group);
+        when(groupService.getGroupById("groupId")).thenReturn(groupDTO);
 
         mockMvc.perform(get("/api/v1/groups/groupId"))
                 .andExpect(status().isOk())
@@ -79,9 +79,9 @@ class GroupControllerTests {
 
     @Test
     void getGroupsByUserIdSuccessfully() throws Exception {
-        Group group1 = new Group();
+        GroupDTO group1 = new GroupDTO();
         group1.setMembers(List.of("user1", "user2"));
-        Group group2 = new Group();
+        GroupDTO group2 = new GroupDTO();
         group2.setMembers(List.of("user1"));
 
         when(groupService.getGroupsByUserId("user1")).thenReturn(List.of(group1, group2));
@@ -107,10 +107,10 @@ class GroupControllerTests {
 
     @Test
     void joinGroupSuccessfully() throws Exception {
-        Group group = new Group();
-        group.setId("groupId");
+        GroupDTO groupDTO = new GroupDTO();
+        groupDTO.setId("groupId");
 
-        when(groupService.joinGroup("groupCode", "userId")).thenReturn(group);
+        when(groupService.joinGroup("groupCode", "userId")).thenReturn(groupDTO);
 
         mockMvc.perform(post("/api/v1/groups/join/groupCode/userId"))
                 .andExpect(status().isOk())
@@ -128,6 +128,4 @@ class GroupControllerTests {
 
         verify(groupService, times(1)).joinGroup("groupCode", "userId");
     }
-
-
 }

--- a/src/test/java/arsw/wherewe/back/papagroups/service/GroupServiceTests.java
+++ b/src/test/java/arsw/wherewe/back/papagroups/service/GroupServiceTests.java
@@ -1,5 +1,6 @@
 package arsw.wherewe.back.papagroups.service;
 
+import arsw.wherewe.back.papagroups.dto.GroupDTO;
 import arsw.wherewe.back.papagroups.model.Group;
 import arsw.wherewe.back.papagroups.repository.GroupRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,40 +32,54 @@ class GroupServiceTests {
 
     @Test
     void createGroupSuccessfully() {
+        // Setup: Create a GroupDTO for input and a Group for the repository
+        GroupDTO groupDTO = new GroupDTO();
+        groupDTO.setAdmin("adminId");
+
         Group group = new Group();
         group.setAdmin("adminId");
+        group.setCode("code123"); // Simulate the generated code
+        group.setMembers(List.of("adminId")); // Set members as per service logic
 
         when(groupRepository.save(any(Group.class))).thenReturn(group);
 
-        Group createdGroup = groupService.createGroup(group);
+        // Execute: Call the service method with GroupDTO
+        GroupDTO createdGroupDTO = groupService.createGroup(groupDTO);
 
-        assertNotNull(createdGroup.getCode());
-        assertEquals(1, createdGroup.getMembers().size());
-        assertEquals("adminId", createdGroup.getMembers().get(0));
-        verify(groupRepository, times(1)).save(group);
+        // Verify: Check the returned GroupDTO
+        assertNotNull(createdGroupDTO.getCode());
+        assertEquals(1, createdGroupDTO.getMembers().size());
+        assertEquals("adminId", createdGroupDTO.getMembers().get(0));
+        verify(groupRepository, times(1)).save(any(Group.class));
     }
 
     @Test
     void getGroupsSuccessfully() {
+        // Setup: Create a list of Group entities for the repository
         List<Group> groups = List.of(new Group(), new Group());
 
         when(groupRepository.findAll()).thenReturn(groups);
 
-        List<Group> result = groupService.getGroups();
+        // Execute: Call the service method
+        List<GroupDTO> result = groupService.getGroups();
 
+        // Verify: Check the returned list of GroupDTOs
         assertEquals(2, result.size());
         verify(groupRepository, times(1)).findAll();
     }
 
     @Test
     void getGroupByIdSuccessfully() {
+        // Setup: Create a Group entity for the repository
         Group group = new Group();
         group.setId("groupId");
 
         when(groupRepository.findById("groupId")).thenReturn(Optional.of(group));
 
-        Group result = groupService.getGroupById("groupId");
+        // Execute: Call the service method
+        GroupDTO result = groupService.getGroupById("groupId");
 
+        // Verify: Check the returned GroupDTO
         assertNotNull(result);
         assertEquals("groupId", result.getId());
         verify(groupRepository, times(1)).findById("groupId");
@@ -74,22 +89,24 @@ class GroupServiceTests {
     void getGroupByIdNotFound() {
         when(groupRepository.findById("groupId")).thenReturn(Optional.empty());
 
-        Group result = groupService.getGroupById("groupId");
+        // Execute: Call the service method
+        GroupDTO result = groupService.getGroupById("groupId");
 
+        // Verify: Check that the result is null
         assertNull(result);
         verify(groupRepository, times(1)).findById("groupId");
     }
 
-
-
     @Test
     void joinGroupUserAlreadyMember() {
+        // Setup: Create a Group entity with a member
         Group group = new Group();
         group.setCode("code123");
         group.setMembers(List.of("user1"));
 
         when(groupRepository.findAll()).thenReturn(List.of(group));
 
+        // Execute & Verify: Expect an exception when the user is already a member
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             groupService.joinGroup("code123", "user1");
         });
@@ -102,6 +119,7 @@ class GroupServiceTests {
     void joinGroupNotFound() {
         when(groupRepository.findAll()).thenReturn(List.of());
 
+        // Execute & Verify: Expect an exception when the group is not found
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             groupService.joinGroup("code123", "user1");
         });
@@ -112,6 +130,7 @@ class GroupServiceTests {
 
     @Test
     void getGroupsByUserIdSuccessfully() {
+        // Setup: Create Group entities with members
         Group group1 = new Group();
         group1.setMembers(List.of("user1", "user2"));
         Group group2 = new Group();
@@ -121,16 +140,19 @@ class GroupServiceTests {
 
         when(groupRepository.findAll()).thenReturn(List.of(group1, group2, group3));
 
-        List<Group> result = groupService.getGroupsByUserId("user1");
+        // Execute: Call the service method
+        List<GroupDTO> result = groupService.getGroupsByUserId("user1");
 
+        // Verify: Check the returned list of GroupDTOs
         assertEquals(2, result.size());
-        assertTrue(result.contains(group1));
-        assertTrue(result.contains(group2));
+        assertTrue(result.stream().anyMatch(dto -> dto.getMembers().contains("user1") && dto.getMembers().contains("user2")));
+        assertTrue(result.stream().anyMatch(dto -> dto.getMembers().contains("user1") && dto.getMembers().size() == 1));
         verify(groupRepository, times(1)).findAll();
     }
 
     @Test
     void getGroupsByUserIdNoGroupsFound() {
+        // Setup: Create Group entities with no matching members
         Group group1 = new Group();
         group1.setMembers(List.of("user2"));
         Group group2 = new Group();
@@ -138,25 +160,35 @@ class GroupServiceTests {
 
         when(groupRepository.findAll()).thenReturn(List.of(group1, group2));
 
-        List<Group> result = groupService.getGroupsByUserId("user1");
+        // Execute: Call the service method
+        List<GroupDTO> result = groupService.getGroupsByUserId("user1");
 
+        // Verify: Check that the result is empty
         assertTrue(result.isEmpty());
         verify(groupRepository, times(1)).findAll();
     }
 
     @Test
     void joinGroupSuccessfully() {
+        // Setup: Create a Group entity with no members
         Group group = new Group();
         group.setCode("code123");
         group.setMembers(new ArrayList<>());
 
+        // Simulate the updated group after adding a member
+        Group updatedGroup = new Group();
+        updatedGroup.setCode("code123");
+        updatedGroup.setMembers(List.of("user1"));
+
         when(groupRepository.findAll()).thenReturn(List.of(group));
-        when(groupRepository.save(any(Group.class))).thenReturn(group);
+        when(groupRepository.save(any(Group.class))).thenReturn(updatedGroup);
 
-        Group result = groupService.joinGroup("code123", "user1");
+        // Execute: Call the service method
+        GroupDTO result = groupService.joinGroup("code123", "user1");
 
+        // Verify: Check the returned GroupDTO
         assertNotNull(result);
         assertTrue(result.getMembers().contains("user1"));
-        verify(groupRepository, times(1)).save(group);
+        verify(groupRepository, times(1)).save(any(Group.class));
     }
 }


### PR DESCRIPTION
This pull request introduces significant changes to the `GroupController` and `GroupService` classes by transitioning from using the `Group` model to the new `GroupDTO` (Data Transfer Object). This refactor aims to improve data handling and separation of concerns between different layers of the application. Additionally, it includes updates to the associated tests to accommodate these changes.

Key changes include:

### Controller and Service Refactor:
* [`src/main/java/arsw/wherewe/back/papagroups/controller/GroupController.java`](diffhunk://#diff-a1082d9b7d06cd0ac875b125287a380168688655055154269794dde57d4ea036L40-R42): Updated all methods to use `GroupDTO` instead of `Group`. This includes changes in the request and response types for methods such as `createGroup`, `getGroups`, `getGroupById`, `joinGroup`, and `getGroupsByUserId`. [[1]](diffhunk://#diff-a1082d9b7d06cd0ac875b125287a380168688655055154269794dde57d4ea036L40-R42) [[2]](diffhunk://#diff-a1082d9b7d06cd0ac875b125287a380168688655055154269794dde57d4ea036L55-R57) [[3]](diffhunk://#diff-a1082d9b7d06cd0ac875b125287a380168688655055154269794dde57d4ea036L71-R73) [[4]](diffhunk://#diff-a1082d9b7d06cd0ac875b125287a380168688655055154269794dde57d4ea036L87-R99) [[5]](diffhunk://#diff-a1082d9b7d06cd0ac875b125287a380168688655055154269794dde57d4ea036L103-R110)

* [`src/main/java/arsw/wherewe/back/papagroups/service/GroupService.java`](diffhunk://#diff-689c4e23f3553c4fd4381c3f453d539b4087a4dedd2e00b5d9a3c8d4095b82a8L26-R69): Introduced methods to map between `Group` and `GroupDTO`. Updated service methods to use `GroupDTO` for all operations, including `createGroup`, `getGroups`, `getGroupById`, `joinGroup`, and `getGroupsByUserId`. [[1]](diffhunk://#diff-689c4e23f3553c4fd4381c3f453d539b4087a4dedd2e00b5d9a3c8d4095b82a8L26-R69) [[2]](diffhunk://#diff-689c4e23f3553c4fd4381c3f453d539b4087a4dedd2e00b5d9a3c8d4095b82a8L49-R79) [[3]](diffhunk://#diff-689c4e23f3553c4fd4381c3f453d539b4087a4dedd2e00b5d9a3c8d4095b82a8L67-R101)

### DTO Introduction:
* [`src/main/java/arsw/wherewe/back/papagroups/dto/GroupDTO.java`](diffhunk://#diff-1eb86d2c371e6d2da372a63f3f5816d7cc2472de9f842851bc77b43fca7e4f61R1-R77): Added a new `GroupDTO` class to represent group data transferred between the client and server. This class includes fields such as `id`, `admin`, `nameGroup`, `members`, and `code`, along with their respective getters and setters.

### Test Updates:
* [`src/test/java/arsw/wherewe/back/papagroups/controller/GroupControllerTests.java`](diffhunk://#diff-100656e55bf47b02f29eea274480b725f33d71b64f59ce21a5ccaedd68d211feL39-R55): Updated test cases to use `GroupDTO` instead of `Group`. This includes modifications in test methods like `createGroupSuccessfully`, `getGroupsSuccessfully`, `getGroupByIdSuccessfully`, `getGroupsByUserIdSuccessfully`, and `joinGroupSuccessfully`. [[1]](diffhunk://#diff-100656e55bf47b02f29eea274480b725f33d71b64f59ce21a5ccaedd68d211feL39-R55) [[2]](diffhunk://#diff-100656e55bf47b02f29eea274480b725f33d71b64f59ce21a5ccaedd68d211feL68-R71) [[3]](diffhunk://#diff-100656e55bf47b02f29eea274480b725f33d71b64f59ce21a5ccaedd68d211feL82-R84) [[4]](diffhunk://#diff-100656e55bf47b02f29eea274480b725f33d71b64f59ce21a5ccaedd68d211feL110-R113) [[5]](diffhunk://#diff-100656e55bf47b02f29eea274480b725f33d71b64f59ce21a5ccaedd68d211feL131-L132)

* [`src/test/java/arsw/wherewe/back/papagroups/service/GroupServiceTests.java`](diffhunk://#diff-d0d8a7429da5f4c6690db54667c243a75ba24772fa3fcfa465d2171bed357695R35-R82): Updated test cases to use `GroupDTO` and added necessary setup for the new DTO. This includes modifications in test methods like `createGroupSuccessfully`, `getGroupsSuccessfully`, `getGroupByIdSuccessfully`, `joinGroupUserAlreadyMember`, and `getGroupsByUserIdSuccessfully`. [[1]](diffhunk://#diff-d0d8a7429da5f4c6690db54667c243a75ba24772fa3fcfa465d2171bed357695R35-R82) [[2]](diffhunk://#diff-d0d8a7429da5f4c6690db54667c243a75ba24772fa3fcfa465d2171bed357695L77-R109) [[3]](diffhunk://#diff-d0d8a7429da5f4c6690db54667c243a75ba24772fa3fcfa465d2171bed357695R122) [[4]](diffhunk://#diff-d0d8a7429da5f4c6690db54667c243a75ba24772fa3fcfa465d2171bed357695R133)