### PR TITLE
FIX PIPELINE

### DIFF
--- a/src/main/java/arsw/wherewe/back/papagroups/service/GroupService.java
+++ b/src/main/java/arsw/wherewe/back/papagroups/service/GroupService.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 /**
  * Group service class for group operations
@@ -58,7 +57,7 @@ public class GroupService {
     public List<GroupDTO> getGroups() {
         return groupRepository.findAll().stream()
                 .map(this::toGroupDTO)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public GroupDTO getGroupById(String id) {
@@ -98,7 +97,7 @@ public class GroupService {
         return groupRepository.findAll().stream()
                 .filter(g -> g.getMembers().contains(userId))
                 .map(this::toGroupDTO)
-                .collect(Collectors.toList());
+                .toList();
     }
 
 }


### PR DESCRIPTION
This pull request includes changes to the `GroupService` class in the `papagroups` service to simplify the code by replacing the `Collectors.toList()` method with the `toList()` method.

Code simplification:

* [`src/main/java/arsw/wherewe/back/papagroups/service/GroupService.java`](diffhunk://#diff-689c4e23f3553c4fd4381c3f453d539b4087a4dedd2e00b5d9a3c8d4095b82a8L12): Removed the import statement for `java.util.stream.Collectors` as it is no longer needed.
* [`src/main/java/arsw/wherewe/back/papagroups/service/GroupService.java`](diffhunk://#diff-689c4e23f3553c4fd4381c3f453d539b4087a4dedd2e00b5d9a3c8d4095b82a8L61-R60): Replaced `Collectors.toList()` with `toList()` in the `getGroups` method.
* [`src/main/java/arsw/wherewe/back/papagroups/service/GroupService.java`](diffhunk://#diff-689c4e23f3553c4fd4381c3f453d539b4087a4dedd2e00b5d9a3c8d4095b82a8L101-R100): Replaced `Collectors.toList()` with `toList()` in the `getGroupsByUserId` method.