### PR TITLE
Fix env

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,8 @@
 							</reports>
 							<excludes>
 								<!-- Excluir la clase CorsConfig del reporte de JaCoCo -->
-								<exclude>**/CorsConfig.class</exclude>
+								<exclude>**/SecurityConfig.class</exclude>
+								<exclude>**/SwaggerConfig.class</exclude>
 							</excludes>
 						</configuration>
 					</execution>


### PR DESCRIPTION
This pull request updates the `pom.xml` file to modify the exclusions in the JaCoCo report configuration. Specifically, it replaces the exclusion of the `CorsConfig` class with exclusions for `SecurityConfig` and `SwaggerConfig`.

Key change:

* Updated the JaCoCo report configuration to exclude `SecurityConfig.class` and `SwaggerConfig.class` instead of `CorsConfig.class` in the `pom.xml` file.