### PR TITLE
Fix env

### DIFF
--- a/src/test/java/arsw/wherewe/back/papagroups/PapagroupsApplicationTests.java
+++ b/src/test/java/arsw/wherewe/back/papagroups/PapagroupsApplicationTests.java
@@ -1,0 +1,16 @@
+package arsw.wherewe.back.papagroups;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@TestPropertySource(properties = {"MONGODB_URI=mongodb://localhost:27017/testdb"})
+class PapagroupsApplicationTests {
+
+	@Test
+	void contextLoads() {
+		// This test is empty because it is only used to check if the context loads
+	}
+
+}


### PR DESCRIPTION
This pull request includes several changes aimed at improving configuration management and test setup for the project. The most important changes involve removing `.env` file dependency, updating test configurations, and refining JaCoCo report exclusions.

### Configuration changes:

* Removed the `.env` file dependency by deleting the `DotEnvConfig` class, which previously loaded environment variables from a `.env` file. This change suggests a shift towards a different configuration management approach. (`src/main/java/arsw/wherewe/back/papagroups/config/DotEnvConfig.java`)
* Deleted the `MONGODB_URI` entry from the `.env` file, further supporting the removal of `.env` file dependency. (`.env`)

### Test setup improvements:

* Added a `@TestPropertySource` annotation to the test class `PapagroupsApplicationTests` to define an inline `MONGODB_URI` property for testing purposes. This ensures tests use a local MongoDB instance instead of relying on external configurations. (`src/test/java/arsw/wherewe/back/papagroups/PapagroupsApplicationTests.java`)

### Code coverage report adjustments:

* Updated the JaCoCo configuration in `pom.xml` to exclude `SecurityConfig` and `SwaggerConfig` classes from the coverage report, replacing the previous exclusion of `CorsConfig`. (`pom.xml`)