### PR TITLE
add delete users from a group

### DIFF
--- a/src/main/java/arsw/wherewe/back/papagroups/controller/GroupController.java
+++ b/src/main/java/arsw/wherewe/back/papagroups/controller/GroupController.java
@@ -129,4 +129,37 @@ public class GroupController {
             return ResponseEntity.noContent().build();
         }
     }
+
+    @DeleteMapping("/leave/{groupId}/{userId}")
+    @Operation(summary = "Leave a specific group", description = "Removes a user from a specific group, reassigning admin if necessary")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "User successfully left the group",
+                    content = @Content(schema = @Schema(implementation = Group.class))),
+            @ApiResponse(responseCode = "404", description = "Group or user not found")
+    })
+    public ResponseEntity<GroupDTO> leaveGroup(@PathVariable("groupId") String groupId, @PathVariable("userId") String userId) {
+        GroupDTO group = groupService.leaveGroup(groupId, userId);
+        if (group != null) {
+            return ResponseEntity.ok(group);
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @DeleteMapping("/expel/{groupId}/{userId}/{adminId}")
+    @Operation(summary = "Expel a member from a group", description = "Allows the admin to remove a member from the group")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Member successfully expelled",
+                    content = @Content(schema = @Schema(implementation = Group.class))),
+            @ApiResponse(responseCode = "403", description = "Only admin can expel members"),
+            @ApiResponse(responseCode = "404", description = "Group, user, or admin not found")
+    })
+    public ResponseEntity<GroupDTO> expelMember(@PathVariable("groupId") String groupId, @PathVariable("userId") String userId, @PathVariable("adminId") String adminId) {
+        GroupDTO group = groupService.expelMember(groupId, userId, adminId);
+        if (group != null) {
+            return ResponseEntity.ok(group);
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+    }
 }

--- a/src/test/java/arsw/wherewe/back/papagroups/controller/GroupControllerTests.java
+++ b/src/test/java/arsw/wherewe/back/papagroups/controller/GroupControllerTests.java
@@ -148,4 +148,52 @@ class GroupControllerTests {
 
         verify(groupService, times(1)).leaveAllGroups("userId");
     }
+
+    @Test
+    void leaveGroupSuccessfully() throws Exception {
+        GroupDTO groupDTO = new GroupDTO();
+        groupDTO.setId("groupId");
+
+        when(groupService.leaveGroup("groupId", "userId")).thenReturn(groupDTO);
+
+        mockMvc.perform(delete("/api/v1/groups/leave/groupId/userId"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value("groupId"));
+
+        verify(groupService, times(1)).leaveGroup("groupId", "userId");
+    }
+
+    @Test
+    void leaveGroupNotFound() throws Exception {
+        when(groupService.leaveGroup("groupId", "userId")).thenReturn(null);
+
+        mockMvc.perform(delete("/api/v1/groups/leave/groupId/userId"))
+                .andExpect(status().isNotFound());
+
+        verify(groupService, times(1)).leaveGroup("groupId", "userId");
+    }
+
+    @Test
+    void expelMemberSuccessfully() throws Exception {
+        GroupDTO groupDTO = new GroupDTO();
+        groupDTO.setId("groupId");
+
+        when(groupService.expelMember("groupId", "userId", "adminId")).thenReturn(groupDTO);
+
+        mockMvc.perform(delete("/api/v1/groups/expel/groupId/userId/adminId"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value("groupId"));
+
+        verify(groupService, times(1)).expelMember("groupId", "userId", "adminId");
+    }
+
+    @Test
+    void expelMemberNotFound() throws Exception {
+        when(groupService.expelMember("groupId", "userId", "adminId")).thenReturn(null);
+
+        mockMvc.perform(delete("/api/v1/groups/expel/groupId/userId/adminId"))
+                .andExpect(status().isNotFound());
+
+        verify(groupService, times(1)).expelMember("groupId", "userId", "adminId");
+    }
 }


### PR DESCRIPTION
This pull request introduces new functionality for managing group membership in the `GroupController` and `GroupService` classes, including the ability for users to leave specific groups and for admins to expel members. It also adds corresponding unit tests to ensure the correctness of these features. Below are the most significant changes:

### New API Endpoints for Group Management
* Added `leaveGroup` endpoint to allow users to leave a specific group, with admin reassignment if necessary (`GroupController.java`).
* Added `expelMember` endpoint to allow admins to remove members from a group, with validation to ensure only admins can perform this action (`GroupController.java`).

### Enhancements to Group Management Logic
* Refactored admin reassignment logic into a new `reassignAdmin` helper method for better code reuse and readability (`GroupService.java`).
* Introduced `isMember` helper method to check if a user is part of a group (`GroupService.java`).
* Implemented `leaveGroup` and `expelMember` methods in `GroupService` to handle the business logic for the new endpoints, including edge cases like deleting a group when the last admin leaves (`GroupService.java`).

### Unit Tests for New Features
* Added tests to validate the `leaveGroup` functionality, including scenarios for successful leave, admin reassignment, and group deletion when the admin is the only member (`GroupServiceTests.java`).
* Added tests for `expelMember` to verify successful member removal and failure cases such as non-admin attempts or invalid group/user IDs (`GroupServiceTests.java`).

### Integration Tests for Controller Endpoints
* Added integration tests for `leaveGroup` and `expelMember` endpoints to verify HTTP responses and service interactions (`GroupControllerTests.java`).