### PR TITLE
fix delete users from a group

### DIFF
--- a/src/main/java/arsw/wherewe/back/papagroups/controller/GroupController.java
+++ b/src/main/java/arsw/wherewe/back/papagroups/controller/GroupController.java
@@ -138,9 +138,9 @@ public class GroupController {
             @ApiResponse(responseCode = "404", description = "Group or user not found")
     })
     public ResponseEntity<GroupDTO> leaveGroup(@PathVariable("groupId") String groupId, @PathVariable("userId") String userId) {
-        GroupDTO group = groupService.leaveGroup(groupId, userId);
-        if (group != null) {
-            return ResponseEntity.ok(group);
+        boolean isDeleted = groupService.leaveGroup(groupId, userId);
+        if (isDeleted) {
+            return ResponseEntity.ok().build();
         } else {
             return ResponseEntity.notFound().build();
         }

--- a/src/main/java/arsw/wherewe/back/papagroups/service/GroupService.java
+++ b/src/main/java/arsw/wherewe/back/papagroups/service/GroupService.java
@@ -177,23 +177,24 @@ public class GroupService {
      * @param userId String user id
      * @return GroupDTO if the user left the group, null if group or user not found
      */
-    public GroupDTO leaveGroup(String groupId, String userId) {
+    public boolean leaveGroup(String groupId, String userId) {
         Optional<Group> groupOptional = groupRepository.findById(groupId);
         if (groupOptional.isPresent()) {
             Group group = groupOptional.get();
             if (group.getMembers().contains(userId)) {
                 if (isAdmin(userId, group) && group.getMembers().size() > 1) {
                     reassignAdmin(group, userId);
-                } else if (isAdmin(userId, group) && group.getMembers().size() == 1) {
-                    groupRepository.deleteById(group.getId());
-                    return null;
                 }
                 group.getMembers().remove(userId);
-                Group updatedGroup = groupRepository.save(group);
-                return toGroupDTO(updatedGroup);
+                if (group.getMembers().isEmpty()) {
+                    groupRepository.deleteById(group.getId());
+                    return true;
+                }
+                groupRepository.save(group);
+                return true;
             }
         }
-        return null;
+        return false;
     }
 
     /**

--- a/src/test/java/arsw/wherewe/back/papagroups/controller/GroupControllerTests.java
+++ b/src/test/java/arsw/wherewe/back/papagroups/controller/GroupControllerTests.java
@@ -150,22 +150,18 @@ class GroupControllerTests {
     }
 
     @Test
-    void leaveGroupSuccessfully() throws Exception {
-        GroupDTO groupDTO = new GroupDTO();
-        groupDTO.setId("groupId");
-
-        when(groupService.leaveGroup("groupId", "userId")).thenReturn(groupDTO);
+    void leaveGroupSuccessfullyReturnsOk() throws Exception {
+        when(groupService.leaveGroup("groupId", "userId")).thenReturn(true);
 
         mockMvc.perform(delete("/api/v1/groups/leave/groupId/userId"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value("groupId"));
+                .andExpect(status().isOk());
 
         verify(groupService, times(1)).leaveGroup("groupId", "userId");
     }
 
     @Test
-    void leaveGroupNotFound() throws Exception {
-        when(groupService.leaveGroup("groupId", "userId")).thenReturn(null);
+    void leaveGroupNotFoundReturnsNotFound() throws Exception {
+        when(groupService.leaveGroup("groupId", "userId")).thenReturn(false);
 
         mockMvc.perform(delete("/api/v1/groups/leave/groupId/userId"))
                 .andExpect(status().isNotFound());

--- a/src/test/java/arsw/wherewe/back/papagroups/service/GroupServiceTests.java
+++ b/src/test/java/arsw/wherewe/back/papagroups/service/GroupServiceTests.java
@@ -294,67 +294,7 @@ class GroupServiceTests {
         verify(groupRepository, never()).save(any(Group.class));
     }
 
-    @Test
-    void leaveGroupSuccessfully() {
-        Group group = new Group();
-        group.setId("groupId");
-        group.setAdmin("adminId");
-        group.setMembers(new ArrayList<>(List.of("adminId", "userId")));
 
-        when(groupRepository.findById("groupId")).thenReturn(Optional.of(group));
-        when(groupRepository.save(any(Group.class))).thenReturn(group);
-
-        GroupDTO result = groupService.leaveGroup("groupId", "userId");
-
-        assertNotNull(result);
-        assertFalse(group.getMembers().contains("userId"));
-        verify(groupRepository, times(1)).save(any(Group.class));
-    }
-
-    @Test
-    void leaveGroupAdminReassigned() {
-        Group group = new Group();
-        group.setId("groupId");
-        group.setAdmin("adminId");
-        group.setMembers(new ArrayList<>(List.of("adminId", "userId", "user2")));
-
-        when(groupRepository.findById("groupId")).thenReturn(Optional.of(group));
-        when(groupRepository.save(any(Group.class))).thenReturn(group);
-
-        GroupDTO result = groupService.leaveGroup("groupId", "adminId");
-
-        assertNotNull(result);
-        assertFalse(group.getMembers().contains("adminId"));
-        assertNotEquals("adminId", group.getAdmin());
-        assertTrue(group.getMembers().contains(group.getAdmin()));
-        verify(groupRepository, times(1)).save(any(Group.class));
-    }
-
-    @Test
-    void leaveGroupDeletedWhenAdminAndOnlyMember() {
-        Group group = new Group();
-        group.setId("groupId");
-        group.setAdmin("adminId");
-        group.setMembers(new ArrayList<>(List.of("adminId")));
-
-        when(groupRepository.findById("groupId")).thenReturn(Optional.of(group));
-
-        GroupDTO result = groupService.leaveGroup("groupId", "adminId");
-
-        assertNull(result);
-        verify(groupRepository, times(1)).deleteById("groupId");
-        verify(groupRepository, never()).save(any(Group.class));
-    }
-
-    @Test
-    void leaveGroupNotFound() {
-        when(groupRepository.findById("groupId")).thenReturn(Optional.empty());
-
-        GroupDTO result = groupService.leaveGroup("groupId", "userId");
-
-        assertNull(result);
-        verify(groupRepository, never()).save(any(Group.class));
-    }
 
     @Test
     void expelMemberSuccessfully() {
@@ -411,5 +351,84 @@ class GroupServiceTests {
 
         assertNull(result);
         verify(groupRepository, never()).save(any(Group.class));
+    }
+
+    @Test
+    void leaveGroupSuccessfullyRemovesUser() {
+        Group group = new Group();
+        group.setId("groupId");
+        group.setAdmin("adminId");
+        group.setMembers(new ArrayList<>(List.of("adminId", "userId")));
+
+        when(groupRepository.findById("groupId")).thenReturn(Optional.of(group));
+        when(groupRepository.save(any(Group.class))).thenReturn(group);
+
+        boolean result = groupService.leaveGroup("groupId", "userId");
+
+        assertTrue(result);
+        assertFalse(group.getMembers().contains("userId"));
+        verify(groupRepository, times(1)).save(any(Group.class));
+    }
+
+    @Test
+    void leaveGroupSuccessfullyDeletesGroupWhenLastMember() {
+        Group group = new Group();
+        group.setId("groupId");
+        group.setAdmin("userId");
+        group.setMembers(new ArrayList<>(List.of("userId")));
+
+        when(groupRepository.findById("groupId")).thenReturn(Optional.of(group));
+
+        boolean result = groupService.leaveGroup("groupId", "userId");
+
+        assertTrue(result);
+        verify(groupRepository, times(1)).deleteById("groupId");
+        verify(groupRepository, never()).save(any(Group.class));
+    }
+
+    @Test
+    void leaveGroupSuccessfullyReassignsAdmin() {
+        Group group = new Group();
+        group.setId("groupId");
+        group.setAdmin("adminId");
+        group.setMembers(new ArrayList<>(List.of("adminId", "userId", "user2")));
+
+        when(groupRepository.findById("groupId")).thenReturn(Optional.of(group));
+        when(groupRepository.save(any(Group.class))).thenReturn(group);
+
+        boolean result = groupService.leaveGroup("groupId", "adminId");
+
+        assertTrue(result);
+        assertFalse(group.getMembers().contains("adminId"));
+        assertNotEquals("adminId", group.getAdmin());
+        assertTrue(group.getMembers().contains(group.getAdmin()));
+        verify(groupRepository, times(1)).save(any(Group.class));
+    }
+
+    @Test
+    void leaveGroupFailsWhenGroupNotFound() {
+        when(groupRepository.findById("groupId")).thenReturn(Optional.empty());
+
+        boolean result = groupService.leaveGroup("groupId", "userId");
+
+        assertFalse(result);
+        verify(groupRepository, never()).save(any(Group.class));
+        verify(groupRepository, never()).deleteById(anyString());
+    }
+
+    @Test
+    void leaveGroupFailsWhenUserNotInGroup() {
+        Group group = new Group();
+        group.setId("groupId");
+        group.setAdmin("adminId");
+        group.setMembers(new ArrayList<>(List.of("adminId", "user2")));
+
+        when(groupRepository.findById("groupId")).thenReturn(Optional.of(group));
+
+        boolean result = groupService.leaveGroup("groupId", "userId");
+
+        assertFalse(result);
+        verify(groupRepository, never()).save(any(Group.class));
+        verify(groupRepository, never()).deleteById(anyString());
     }
 }


### PR DESCRIPTION
This pull request refactors the `leaveGroup` functionality in the `GroupService` and its related components to simplify the logic and improve test coverage. The most significant changes include modifying the return type of `leaveGroup` to a `boolean`, updating the controller and service logic accordingly, and revising the associated test cases to reflect the new behavior.

### Refactoring of `leaveGroup` logic:
* Changed the return type of `leaveGroup` in `GroupService` from `GroupDTO` to `boolean` to indicate success or failure. The logic now deletes the group if it becomes empty and returns `true` or `false` based on the operation's success. (`src/main/java/arsw/wherewe/back/papagroups/service/GroupService.java`, [src/main/java/arsw/wherewe/back/papagroups/service/GroupService.javaL180-R197](diffhunk://#diff-689c4e23f3553c4fd4381c3f453d539b4087a4dedd2e00b5d9a3c8d4095b82a8L180-R197))

* Updated the `GroupController` to handle the new `boolean` return type from `leaveGroup`. The controller now returns an HTTP 200 status without a body for successful operations and 404 for failures. (`src/main/java/arsw/wherewe/back/papagroups/controller/GroupController.java`, [src/main/java/arsw/wherewe/back/papagroups/controller/GroupController.javaL141-R143](diffhunk://#diff-a1082d9b7d06cd0ac875b125287a380168688655055154269794dde57d4ea036L141-R143))

### Updates to test cases:
* Modified `GroupControllerTests` to validate the new behavior of `leaveGroup`. Tests now check for HTTP 200 or 404 responses without relying on a `GroupDTO` object. (`src/test/java/arsw/wherewe/back/papagroups/controller/GroupControllerTests.java`, [src/test/java/arsw/wherewe/back/papagroups/controller/GroupControllerTests.javaL153-R164](diffhunk://#diff-100656e55bf47b02f29eea274480b725f33d71b64f59ce21a5ccaedd68d211feL153-R164))

* Refactored and expanded `GroupServiceTests` to cover all possible scenarios for `leaveGroup`, including cases where the group is deleted, the admin is reassigned, the user is not in the group, or the group is not found. (`src/test/java/arsw/wherewe/back/papagroups/service/GroupServiceTests.java`, [[1]](diffhunk://#diff-d0d8a7429da5f4c6690db54667c243a75ba24772fa3fcfa465d2171bed357695L307-R357) [[2]](diffhunk://#diff-d0d8a7429da5f4c6690db54667c243a75ba24772fa3fcfa465d2171bed357695L369-R432)

### Cleanup and naming adjustments:
* Renamed and reorganized several test methods in `GroupServiceTests` to improve clarity and align with the new `leaveGroup` behavior. (`src/test/java/arsw/wherewe/back/papagroups/service/GroupServiceTests.java`, [src/test/java/arsw/wherewe/back/papagroups/service/GroupServiceTests.javaR297-R300](diffhunk://#diff-d0d8a7429da5f4c6690db54667c243a75ba24772fa3fcfa465d2171bed357695R297-R300))